### PR TITLE
feat(ats/zkp): improve error handling and add calculate_commitment function

### DIFF
--- a/ats/zkp-wasm/README.md
+++ b/ats/zkp-wasm/README.md
@@ -6,7 +6,7 @@ It is designed to be used in **Next.js, Node.js, and browser environments** to c
 ## Overview
 
 The `ats-zkp-wasm` crate is a thin WASM façade on top of [`ats-zkp`](../zkp).
-It provides a minimal, **JS-friendly API** with hex strings and plain objects as inputs/outputs, and gives you three high-level functions:
+It provides a minimal, **JS-friendly API** with hex strings and plain objects as inputs/outputs, and gives you four high-level functions:
 
 - **`build_bundle(title, audioBytes, creators, timestampBigInt)` -> `{ bundle }`**
   Computes:
@@ -14,6 +14,12 @@ It provides a minimal, **JS-friendly API** with hex strings and plain objects as
   - a fresh random `secret`
   - Poseidon `commitment` and `nullifier`
   Returns everything as **hex strings**. Note: `bundle.timestamp` is the **timestamp encoded as an `Fr` hex**, ready to pass to proof/verify.
+
+- **`calculate_commitment(title, audioBytes, creators, secretHex)` -> `commitmentHex`**
+  Computes the Poseidon hash commitment from the provided inputs using an **existing secret**:
+  - `hash_title`, `hash_audio`, `hash_creators` (computed internally)
+  - `commitment` = Poseidon(`hash_title`, `hash_audio`, `hash_creators`, `secret`)
+  Returns the **commitment as a hex string**. Use this when you already have a secret (e.g., from a previous `build_bundle` call) and need to recompute or verify the commitment.
 
 - **`prove(pkHex, secretHex, publicsArray)` -> `{ proof, publics }`**
   Generates a Groth16 proof using the **compressed PK** (0x-hex) and **6 public inputs** in this exact order:

--- a/ats/zkp-wasm/js-example/example.js
+++ b/ats/zkp-wasm/js-example/example.js
@@ -1,5 +1,6 @@
 const {
   build_bundle,
+  calculate_commitment,
   prove,
   verify,
 } = require('../pkg-node/allfeat_ats_zkp_wasm.js');
@@ -27,6 +28,12 @@ const fs = require('node:fs');
         bundle.nullifier,
     ];
     console.log('secret (DO NOT REVEAL):', secret);
+
+    // Example: Recompute the commitment using an existing secret
+    // This is useful when you want to verify or recompute the commitment later
+    const recomputedCommitment = calculate_commitment(title, audioBytes, creators, secret);
+    console.log('recomputed commitment:', recomputedCommitment);
+    console.log('commitments match:', recomputedCommitment === bundle.commitment);
 
     // Generate the proof
     const { proof, publics: publicsProof } = prove(PK, secret, publics);

--- a/ats/zkp-wasm/src/lib.rs
+++ b/ats/zkp-wasm/src/lib.rs
@@ -132,6 +132,29 @@ pub fn build_bundle(
     serde_wasm_bindgen::to_value(&out).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
+/// Calculate the hash commitment from the provided inputs:
+/// - inputs: `title`, `audio_bytes` (Uint8Array), `creators` (array of JsCreator), `secret` (hex string)
+/// - returns: commitment as hex string
+#[wasm_bindgen]
+pub fn calculate_commitment(
+    title: &str,
+    audio_bytes: &[u8],
+    creators_js: JsValue,
+    secret: &str,
+) -> Result<String, JsValue> {
+    // 1) hashes (your current helpers return HEX `String`)
+    let hash_title = hash_title(title);
+    let hash_audio = hash_audio(audio_bytes);
+    let creators_core = js_creators_to_core(creators_js)?;
+    let hash_creators = hash_creators(&creators_core);
+
+    // 2) commitment (hex)
+    let commitment = compute_commitment(&hash_title, &hash_audio, &hash_creators, secret)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    Ok(commitment)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProveOutput {
     pub proof: String,

--- a/ats/zkp/src/error.rs
+++ b/ats/zkp/src/error.rs
@@ -1,0 +1,73 @@
+//! Error types for the ZKP crate.
+//!
+//! This module defines a comprehensive error type [`ZkpError`] that captures
+//! all failure modes in proof generation, verification, and input processing.
+
+/// Comprehensive error type for ZKP operations.
+///
+/// Distinguishes between different failure modes to enable proper error handling
+/// and debugging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZkpError {
+    /// Invalid hex string provided (malformed or wrong length).
+    ///
+    /// Contains the field name and description of the issue.
+    InvalidHex,
+
+    /// Wrong number of public inputs provided.
+    ///
+    /// Expected 6 inputs in order: hash_title, hash_audio, hash_creators,
+    /// commitment, timestamp, nullifier.
+    WrongPublicInputCount,
+
+    /// Failed to generate proof.
+    ///
+    /// This typically indicates a constraint system error or RNG failure.
+    ProofGenerationFailed,
+
+    /// Failed to verify proof.
+    ///
+    /// This is different from verification returning `false` - it indicates
+    /// an error in the verification process itself.
+    VerificationError,
+
+    /// Failed to serialize or deserialize cryptographic objects (keys, proofs).
+    SerializationFailed,
+
+    /// Failed to deserialize cryptographic objects (keys, proofs).
+    DeserializationFailed,
+
+    /// Input data is too large (e.g., hex string exceeds field size).
+    InputTooLarge,
+}
+
+impl core::fmt::Display for ZkpError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ZkpError::InvalidHex => {
+                write!(f, "Invalid hex string")
+            }
+            ZkpError::WrongPublicInputCount => {
+                write!(f, "Wrong number of public inputs")
+            }
+            ZkpError::ProofGenerationFailed => {
+                write!(f, "Proof generation failed")
+            }
+            ZkpError::VerificationError => {
+                write!(f, "Verification error")
+            }
+            ZkpError::SerializationFailed => {
+                write!(f, "Serialization failed")
+            }
+            ZkpError::DeserializationFailed => {
+                write!(f, "Deserialization failed")
+            }
+            ZkpError::InputTooLarge => {
+                write!(f, "Input too large")
+            }
+        }
+    }
+}
+
+/// Specialized `Result` type for ZKP operations.
+pub type Result<T> = core::result::Result<T, ZkpError>;

--- a/ats/zkp/src/lib.rs
+++ b/ats/zkp/src/lib.rs
@@ -1,6 +1,7 @@
 use ark_bn254::{Bn254, Fr};
 
 pub mod circuit;
+pub mod error;
 pub mod hashing;
 pub mod utils;
 pub mod zkp;
@@ -10,6 +11,7 @@ pub type Curve = Bn254;
 pub type F = Fr;
 
 pub use circuit::*;
+pub use error::*;
 pub use hashing::*;
 pub use utils::*;
 pub use zkp::*;


### PR DESCRIPTION
## feat(ats/zkp): introduce comprehensive ZkpError type for improved error handling and add calculate_commitment function

### Overview
This PR replaces scattered `ark_serialize::SerializationError` usage throughout the **`ats/zkp`** crate with a **custom, 
domain-specific `ZkpError` type**.
The new error type provides **granular error variants** for each failure mode in ZKP operations, enabling **better debugging**,
**clearer error messages**, and a **more maintainable error-handling strategy** across the entire proof system.

**Additionally**, this PR introduces the **`calculate_commitment()` function** for computing Poseidon hash commitments using an existing secret, complementing the existing `build_bundle()` workflow.

### Key Features

#### Core (`ats/zkp`)
- **Dedicated error module (`error.rs`)**
  - `ZkpError` enum with 7 distinct variants:
    - `InvalidHex`: malformed or incorrectly formatted hex strings
    - `WrongPublicInputCount`: public inputs array length mismatch (expected 6)
    - `ProofGenerationFailed`: Groth16 proof creation errors
    - `VerificationError`: proof verification process failures (distinct from `false` result)
    - `SerializationFailed`: cryptographic object serialization errors
    - `DeserializationFailed`: cryptographic object deserialization errors
    - `InputTooLarge`: input data exceeds field size limits
  - `Display` implementation with human-readable error messages
  - Type alias `Result<T> = core::result::Result<T, ZkpError>` for consistency

- **Comprehensive refactoring across modules**
  - **`circuit.rs`**: all test functions now use `Result<()>` instead of `Result<(), SerializationError>`
  - **`utils.rs`**: `fr_from_hex_be`, `poseidon_commitment_offchain`, `poseidon_nullifier_offchain` return `Result<Fr>` / `Result<String>`
  - **`zkp.rs`**: `setup`, `prove`, `verify` functions return specialized `Result` types with `ZkpError`
  - Replaced generic `SerializationError::InvalidData` with semantically meaningful variants

- **Improved error propagation**
  - Hex parsing errors now return `InvalidHex` instead of generic serialization failure
  - Oversized input detection uses `InputTooLarge` variant
  - Proof system errors distinguished between generation (`ProofGenerationFailed`) and verification (`VerificationError`)

- **Refactored commitment/nullifier computation**
  - Split `compute_commitment_nullifier` into separate `compute_commitment` and `compute_nullifier` functions for better modularity
  - Enables independent commitment calculation without nullifier generation

#### WASM Bindings (`ats-zkp-wasm`)
- **Updated imports and signatures**
  - Imports `ZkpError` instead of `SerializationError`
  - `compute_commitment` and `compute_nullifier` now return `Result<String, ZkpError>`
  - Test functions use `Result<(), ZkpError>` for consistency
  - Error messages improved (e.g., "Failed to parse creators" instead of "Invalid creators JSON")

- **New `calculate_commitment()` function**
  - **Signature**: `calculate_commitment(title, audioBytes, creators, secretHex) -> Result<String, JsValue>`
  - **Purpose**: Compute Poseidon commitment using an existing secret (without generating a new random one)
  - **Use cases**:
    - Recomputing commitments for verification
    - Reconstructing commitments from stored secrets
    - Independent commitment calculation in multi-step workflows
  - **Complements** `build_bundle()` which generates a fresh random secret and full bundle

- **Documentation and examples**
  - Updated README with `calculate_commitment()` API documentation
  - Added JavaScript example demonstrating commitment recomputation
  - Included Next.js integration example
  - Comprehensive test coverage for deterministic commitment calculation

### Why It Matters
- **Eliminates misuse of `SerializationError`** for non-serialization failures (e.g., hex parsing, input validation)
- **Provides actionable error context** for debugging failed proofs, invalid inputs, or cryptographic operations
- **Aligns with Rust best practices** by using domain-specific error types instead of generic library errors
- **Maintains `no_std` compatibility** via `core::fmt::Display` (no dependency on `std::error::Error`)
- **Simplifies integration** for WASM/JS consumers with clearer error messaging at FFI boundaries
- **Establishes foundation** for future error context enrichment (field names, input values, constraint violations)
- **Enhances flexibility** with `calculate_commitment()` for scenarios where commitment computation is needed independently from full bundle generation